### PR TITLE
fix: automatically select single item in filter bar

### DIFF
--- a/components/FilterBar.tsx
+++ b/components/FilterBar.tsx
@@ -36,6 +36,12 @@ const FilterBar = ({
 
   // When enabled, set default filter based on timeOfDay if none is selected.
   useEffect(() => {
+    // If there's only one item, automatically select it
+    if (items.length === 1 && !selectedItem) {
+      setSelectedItem(items[0].id);
+      return;
+    }
+
     if (useTimeOfDayDefault && !selectedItem) {
       const tod = timeOfDay(new Date()); // 'morning', 'afternoon', or 'evening'
       let defaultFilter = '';


### PR DESCRIPTION
Automatically selects the only item in the filter bar when it is the only option available.